### PR TITLE
Handle `bundle outdated` output from >= 1.10.0

### DIFF
--- a/lib/gem_fresh/outdated.rb
+++ b/lib/gem_fresh/outdated.rb
@@ -7,11 +7,40 @@ module GemFresh
       figure_out_outdated_gems
     end
 
-  private
+    private
 
     def figure_out_outdated_gems
       @gem_info ={}
       raw_gem_info_from_bundler.each do |line|
+        line =~ /\A\s*\*\s+(\S+)\s+\((.+)\).*\Z/
+        gem_name = $1
+        version_data = $2
+        @gem_info[gem_name] = extract_versions(version_data)
+      end
+    end
+
+    def extract_versions(data_string)
+      # It looks like Bundler changed the format of the data
+      # returned by `bundle outdated` in version 1.10.
+      # Potential future refactor: decide which extraction
+      # method to use by actually asking Bundler which version
+      # it is and using the appropriate method for that version.
+      # Also: Bundler 1.12 will support `bundle outdated --parseable`
+      # which looks custom-made for this use case.
+      if data_string.include?("newest")
+        #
+        # Sample lines from `bundle outdated` look like this:
+        #
+        # * rspec-rails (newest 3.4.0, installed 3.2.3, requested ~> 3.2.3) in groups "development, test"
+        # * zeus (newest 0.15.4, installed 0.13.3) in group "test"
+        # * websocket-driver (newest 0.6.3, installed 0.5.4)
+        #
+        versions = data_string.split(', ').map(&:strip).map(&:split) # [["newest", "4.2.5"], ["installed", "3.2.22"], ["requested", "=", "3.2.22"]]
+        version_hash = {}
+        versions.each { |v| version_hash[v.first.to_sym] = v.last unless v.size > 2 }
+        return { available_version: GemVersion.new(version_hash[:newest]),
+                  current_version: GemVersion.new(version_hash[:installed]) }
+      else
         #
         # Sample lines from `bundle outdated` look like this:
         #
@@ -20,20 +49,12 @@ module GemFresh
         #   * bootstrap-multiselect-rails (0.9.5 > 0.0.4)
         #   * byebug (3.5.1 > 2.5.0)
         #   * enum_field (0.2.0 bff7873 > 0.2.0)
-        # or this:
-        #   * responders (newest 2.1.0, installed 1.1.2) in group "default"
-        #   * resque-retry (newest 1.4.0, installed 1.3.2) in group "default"
-        #   * resque-status (newest 0.5.0, installed 0.4.1, requested = 0.4.1) in group "default"
-        #   * rspec (newest 3.3.0, installed 3.2.0, requested ~> 3.2.0) in groups "development, test"
         #
-        words = line.split
-        words_that_contain_version_numbers = words.select {|word| word =~ /\d+\.\d+/ }
-        version_numbers = words_that_contain_version_numbers.map {|word| word.gsub(/[\(\),]/, '') }
-        line =~ /\A\s*\*\s+(\S+)/
-        gem_name = $1
-        @gem_info[gem_name] = { available_version: GemVersion.new(version_numbers[0]),
-                                current_version: GemVersion.new(version_numbers[1]) }
-     end
+        versions = data_string.split(" > ").map(&:strip)  # ["0.2.0 bff7873", "0.2.0"]
+        versions = versions.map{|v| v.split(/\s/).first} # ["0.2.0", "0.2.0"]
+        return { available_version: GemVersion.new(versions.first),
+                  current_version: GemVersion.new(versions.last) }
+      end
     end
 
     def raw_gem_info_from_bundler

--- a/lib/gem_fresh/version.rb
+++ b/lib/gem_fresh/version.rb
@@ -1,3 +1,3 @@
 module GemFresh
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
This just sniffs the output to determine which way to parse it; it might be classier to actually ask Bundler which version is present and parse appropriately.

Closes #2 .
