### PR TITLE
Catch the cases where the version string is nil

### DIFF
--- a/lib/gem_fresh/gem_version.rb
+++ b/lib/gem_fresh/gem_version.rb
@@ -6,8 +6,12 @@ module GemFresh
     # 7.6.2.11, 7.6, or even 7.6.2.beta. We just care about the first
     # three numbers
     def initialize(version_string)
-      @major, @minor, @patch = version_string.split('.').map(&:to_i)
-      @patch ||= 0
+      begin
+        @major, @minor, @patch = version_string.split('.').map(&:to_i)
+        @patch ||= 0
+      rescue NoMethodError
+        @major, @minor, @patch = [0,0,0]
+      end
     end
   end
 end

--- a/lib/gem_fresh/version.rb
+++ b/lib/gem_fresh/version.rb
@@ -1,3 +1,3 @@
 module GemFresh
-  VERSION = "0.1.6"
+  VERSION = "0.1.7"
 end


### PR DESCRIPTION
If a gem comes back with an empty version string (not sure how this happens) we should keep going, rather than throwing an exception.